### PR TITLE
Fix issues when there are no duplicates (resolves #42)

### DIFF
--- a/tests/testthat/test-dedup.R
+++ b/tests/testthat/test-dedup.R
@@ -56,7 +56,7 @@ test_that("Essential column missing", {
 # Test case: Deduplication performing as normal
 test_that("Deduplication performing as normal", {
   res <- dedup_citations(test_citations, merge_citations = FALSE, manual_dedup = FALSE)
-  expect_equal(length(res$duplicate_id), 586)
+  expect_equal(length(res$unique$duplicate_id), 586)
 })
 
 # Test case: Deduplication with merge performing as normal


### PR DESCRIPTION
At present, there are a couple of issues when there are no duplicates - that I aimed to fix here.

- Most importantly, the Shiny crashes because return and withProgress do not work as expected - this is resolved here.
- Also, the returns do not include record_ids, only duplicate_ids, which can break pipelines, e.g., in CiteSource - so this always returns `record_ids`
- The check whether there were no duplicates happened 4 times in each version (shiny and not) - here I collapsed it to two times each (could go further, but that would require refactoring).
- The function would return no manual duplicate element if no duplicates were found - now, an empty data.frame is returned to make further processing more robust and more transparent.

Minor point:
- In line with the documentation, the function always returns a list - yet one of the tests still expected a data.frame and thus failed. I fixed that as well.